### PR TITLE
fix: resolve rollup-plugin-node-resolve deprecations

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = {
           file: 'mock-socket.js',
           format: 'amd'
         },
-        plugins: [buble(), resolve({ jsnext: true, main: true }), commonjs()]
+        plugins: [buble(), resolve({ mainFields: ['jsnext', 'main'] }), commonjs()]
       }
     });
 


### PR DESCRIPTION
The `jsnext` and `main` options are deprecated and replaced by a single `mainFields` option. To figure out the correct order, I referenced the rollup-plugin-node-resolve test suite:

https://github.com/rollup/rollup-plugin-node-resolve/blob/6accfb15d026ad02798386799fc0a97a74ce8886/test/test.js#L539

Fixes #18.